### PR TITLE
rename "strains" -> "research" per #95 more globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This page describes the file structure and the taxonomy of xpmethod.github.io
 Everything is either a post or a page. Pages are in the root folder with a `.md` extension, and connect to `.html` layouts in the `_layouts` folder. Pages have tags and categories and a bunch of other fields described in the YAML block.
 
 - `events.html` drives the **events** page which lists all posts in the category `events`
-- `strains.html` drives the **research** page, which lists all categories, *except* for `events`
+- `research.html` drives the **research** page, which lists all categories, *except* for `events`
 - `strain.html` drives the single strain view, that lists all projects in a given category (except for `events`)
 - `project.html` drives the single project view
 - there is no "projects" view yet

--- a/_layouts/research.html
+++ b/_layouts/research.html
@@ -21,7 +21,7 @@ layout: default
 <div class="cats">
     {{ content }}
 
-    {% for post in site.categories['strains'] %}
+    {% for post in site.categories[page.title] %}
      
         {% if post.title != null %}
             <h3><a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></h3>

--- a/_posts/2014-09-01-minimal-computing.md
+++ b/_posts/2014-09-01-minimal-computing.md
@@ -1,7 +1,7 @@
 ---
 layout: strain
 title: minimal-computing
-category: strains
+category: research
 ---
 
 <!-- A 75-100 word paragraph describing the motivation behind these projects -->

--- a/_posts/2014-10-11-public-discourse.md
+++ b/_posts/2014-10-11-public-discourse.md
@@ -1,7 +1,7 @@
 ---
 layout: strain
 title: public-discourse
-category: strains
+category: research
 ---
 
 <!-- A 75-100 word paragraph describing the motivation behind these projects -->

--- a/_posts/2014-10-13-on-method.md
+++ b/_posts/2014-10-13-on-method.md
@@ -1,7 +1,7 @@
 ---
 layout: strain
 title: theory-method
-category: strains
+category: research
 ---
 
 <!-- A 75-100 word paragraph describing the motivation behind these projects -->

--- a/archive/strains-14.md
+++ b/archive/strains-14.md
@@ -1,5 +1,5 @@
 ---
-layout: strains
+layout: research
 title: research
 issue: 14
 ---

--- a/research.md
+++ b/research.md
@@ -1,5 +1,5 @@
 ---
-layout: strains
+layout: research
 title: research
 issue: 15
 ---


### PR DESCRIPTION
This just renames "strains" to "research" in areas like the layout names. It cleans up the code a little bit and makes the code more consistent with the compiled HTML.  