### PR TITLE
Hyphen fix

### DIFF
--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -24,6 +24,6 @@ layout: default
 <!-- want fancy footnotes on faculy links -->
 <!-- filters are the only way to get markdown to render -->
 <p>
-{% capture my-include %}{% include mods.md %}{% endcapture %}
-{{ my include | markdownify }}
+{% capture myinclude %}{% include mods.md %}{% endcapture %}
+{{ myinclude | markdownify }}
 </p>

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -25,5 +25,5 @@ layout: default
 <!-- filters are the only way to get markdown to render -->
 <p>
 {% capture my-include %}{% include mods.md %}{% endcapture %}
-{{ my-include | markdownify }}
+{{ my include | markdownify }}
 </p>


### PR DESCRIPTION
It's possible that the hyphen in the variable name is breaking the build. This removes the hyphen(s) so that Jekyll builds correctly, hopefully.