### PR TITLE
Check broken links with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
-install: gem install jekyll html-proofer
+install: gem install jekyll html-proofer --empty-alt-ignore
 script: jekyll build && htmlproofer ./_site
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: ruby
+rvm:
+- 2.1
+
+# Assume bundler is being used, therefore
+# the `install` step will run `bundle install` by default.
+install: gem install jekyll html-proofer
+script: jekyll build && htmlproofer ./_site
+
+# branch whitelist, only for GitHub Pages
+branches:
+  only:
+  - gh-pages     # test the gh-pages branch
+  - /pages-(.*)/ # test every branch which starts with "pages-"
+
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+
+sudo: false # route your build to the container-based infrastructure for a faster build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ rvm:
 install: gem install jekyll html-proofer
 script: jekyll build && htmlproofer ./_site
 
-# branch whitelist, only for GitHub Pages
-branches:
-  only:
-  - gh-pages     # test the gh-pages branch
-  - /pages-(.*)/ # test every branch which starts with "pages-"
-
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ rvm:
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
-install: gem install jekyll html-proofer --empty-alt-ignore
-script: jekyll build && htmlproofer ./_site
+install: gem install jekyll html-proofer
+script: jekyll build && htmlproofer ./_site --empty-alt-ignore
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This page describes the file structure and the taxonomy of xpmethod.github.io
 
+[![Build Status](https://travis-ci.org/JonathanReeve/xpmethod.github.io.svg?branch=master)](https://travis-ci.org/JonathanReeve/xpmethod.github.io)
+
 ## Logic
 
 Everything is either a post or a page. Pages are in the root folder with a

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-This page describes the file structure and the taxonomy of xpmethod.github.io
-
+#xpmethod.github.io
 [![Build Status](https://travis-ci.org/JonathanReeve/xpmethod.github.io.svg?branch=master)](https://travis-ci.org/JonathanReeve/xpmethod.github.io)
+
+This page describes the file structure and the taxonomy of xpmethod.github.io
 
 ## Logic
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,11 @@ permalink: none
 include: ['_pages']
 # relative_permalinks: false
 
+
+# Since Travis installs gems to /vendor, we have to remove
+# this to keep Travis from checking everything in /vendor.
+exclude: ['vendor'] 
+
 # People Data -----------------------------------------
 rollcall:
     -last-name: Tenen


### PR DESCRIPTION
Following @prpole's request for broken link checking, here's a simple Travis CI integration. On every push to this repo, Travis CI will spin up a fresh VM, install ruby and html-proofer, and check this repo for link and other HTML errors. If the build fails, it'll send emails and change the image in the readme to read "build|failing." Right now, it fails with a few broken links, but hopefully we can get this to pass soon. Here's an example build output: https://travis-ci.org/JonathanReeve/xpmethod.github.io/builds/157522922

Basically, this will help to prevent us from accidentally committing and pushing something that breaks the site. 
