### PR TITLE
Fix Travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.
-install: gem install jekyll html-proofer
+install: gem install jekyll html-proofer jekyll-redirect-from
 script: jekyll build && htmlproofer ./_site --empty-alt-ignore
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.3
+- 2.3.3
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
-rvm:
-- 2.1
+#rvm:
+#- 2.2
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
-#rvm:
-#- 2.2
+rvm:
+- 2.3
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.


### PR DESCRIPTION
This just upgrades the Ruby version used by Travis, and adds a gem that Jekyll uses, so that the html-proofer runs correctly. 