### PR TITLE
Move contributor website URLs to YAML data file, fixes #198 and fixes #191

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,18 @@ This section describes the fields in the site's YAML taxonomy.
 `layout:` looks for the corresponding .html in `_layouts/`  
 `title:` accessible though the `post.title` liquid tag  
 
-```
+```yaml
 tags:
  - Manan Ahmed
  - Alex Gil
  - Dennis Tenen
  - Grant Wythoff
 ```
-Used to pull out the contributors on the "People" page and for project description in "strain" and "project" views. Should be plural and using the dash list as illustrated above (even for singular tags!)  
+Used to pull out the contributors on the "People" page and for project description in "strain" and "project" views. Should be plural and using the dash list as illustrated above (even for singular tags!). If you’d like your contributor name to link to your personal website, add your name to `_data/contributors.yaml`, with your url, in the form: 
 
-Tags can also include URL using the following convention:
-
-```
-tags:
-- name: Author Name
-  url: http://www.authorsite.com
+```yaml
+Author Name: 
+ - url: http://authorsite.com
 ```
 
 If you use a name/url for one post, please make sure it is consistent with the
@@ -76,7 +73,7 @@ Try to keep the snippets clean for this reason.
 `image:` an image can be handled by this tag to gracefully handle image
 snippets. Avoid embedding images into the post otherwise.
 
-```
+```yaml
 images:
  - image1.jpg
  - image2.jpg
@@ -98,6 +95,6 @@ The site was originally forked from
 - set your editor to hard-wrap at 78 characters
 - if you are using vim, use the sample .vimrc file provided here for lab
 defaults
-- for links to static pages use internet archive snapshots as much as possible to minimize link rot
+- for links to static pages use Internet Archive snapshots as much as possible to minimize link rot
 - for simple issues use the [TODO.md](https://github.com/xpmethod/xpmethod.github.io/blob/master/TODO.md) file
 - travis

--- a/_data/contributors.yaml
+++ b/_data/contributors.yaml
@@ -1,0 +1,14 @@
+Dennis Yi Tenen: 
+  url: http://denten.plaintext.in
+
+Jonathan Reeve:
+  url: http://jonreeve.com
+
+Moacir P. de Sá Pereira: 
+  url: http://moacir.com
+
+Emily Fuhrman: 
+  url: http://emilyfhrman.co
+
+Casey Michael Henry:
+  url: http://jailofmountjoy.newmedialab.cuny.edu

--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -8,13 +8,14 @@ layout: default
 <!-- people are tags, it was the fastest way to avoid duplicate names when iterating-->
 
 <ul class="people-list">
-        {% for tag in site.tags %}
-            {% if tag[0].url %}
-                <li><a href="{{ tag[0].url }}">{{ tag[0].name }}</a></li>
-            {% else %}
-                <li>{{ tag[0] }}</li>
-        {% endif %}
-        {% endfor %}
+	{% for tag in site.tags %}
+	{% assign name = tag[0] %}
+	{% if site.data.contributors[name].url %}
+	<li><a href="{{ site.data.contributors[name].url }}">{{ name }}</a></li>
+	{% else %}
+	<li>{{ name }}</li>
+	{% endif %}
+	{% endfor %}
 </ul>
 
 <h2>Faculty Moderators</h2>

--- a/_posts/events/2017-02-10-advanced-text-analysis.md
+++ b/_posts/events/2017-02-10-advanced-text-analysis.md
@@ -8,8 +8,7 @@ categories:
 - events
 hour: 10am-12pm
 tags:
- - name: Jonathan Reeve
-   url: http://jonreeve.com
+ - Jonathan Reeve
 ---
 
 Led by [Jonathan Reeve](http://jonreeve.com). For more information about this and other NYCDH Week workshops see: <http://dhweek.nycdh.org/event/advanced-text-analysis-with-spacy-and-scikit-learn/>

--- a/_posts/projects/2014-08-28-annotag.md
+++ b/_posts/projects/2014-08-28-annotag.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "Annotags: Decentralized Literary Annotation"
-tags:
-- name: Jonathan Reeve
-  url: http://jonreeve.com
+tags: 
+ - Jonathan Reeve
 category: knowledge-design-studio
 type: protocol
 image: annotag.jpg

--- a/_posts/projects/2014-10-11-tinyisbn.md
+++ b/_posts/projects/2014-10-11-tinyisbn.md
@@ -1,8 +1,8 @@
 ---
 layout: project
 title: TinyISBN
-tags:
-- Jonathan Reeve
+tags:  
+ - Jonathan Reeve
 category: public-discourse
 type: web-app
 published: false

--- a/_posts/projects/2014-10-22-visualizing-joyce.md
+++ b/_posts/projects/2014-10-22-visualizing-joyce.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "Visualizing Joyce"
-tags:
-- name: Emily Fuhrman
-  url: http://emilyfuhrman.co
+tags: 
+ - Emily Fuhrman
 category: literary-modeling-and-visualization-lab
 type: graphic
 snippet: 105

--- a/_posts/projects/2015-04-10-mapping-indexality.md
+++ b/_posts/projects/2015-04-10-mapping-indexality.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "Mapping Indexicality"
-tags:
-- name: Emily Fuhrman
-  url: http://emilyfuhrman.co
+tags: 
+ - Emily Fuhrman
 category: embodied-space-lab
 type: graphic
 published: true

--- a/_posts/projects/2015-10-04-git-lit.md
+++ b/_posts/projects/2015-10-04-git-lit.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "Git-Lit"
-tags:
-- name: Jonathan Reeve
-  url: http://jonreeve.com
+tags: 
+ - Jonathan Reeve
 category: knowledge-design-studio
 type: archive
 published: true

--- a/_posts/projects/2016-12-03-text_divider.md
+++ b/_posts/projects/2016-12-03-text_divider.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "Text Divider: Quick Markup for Chapter and Dialogue Splitting"
-tags:
-- name: Moacir P. de Sá Pereira
-  url: http://moacir.com
+tags: 
+ - Moacir P. de Sá Pereira
 category: literary-modeling-and-visualization-lab
 type: markup
 image: url-alice.png

--- a/_posts/projects/2016-12-04-nywalker.md
+++ b/_posts/projects/2016-12-04-nywalker.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "NYWalker: Hand-Geocode Texts"
-tags:
-- name: Moacir P. de Sá Pereira
-  url: http://moacir.com
+tags: 
+ - Moacir P. de Sá Pereira
 category: embodied-space-lab
 type: geocoding
 image: nywalker.png

--- a/_posts/projects/2017-01-07-mapping-fabula-and-sjuzet.md
+++ b/_posts/projects/2017-01-07-mapping-fabula-and-sjuzet.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "Mapping Fabula and Sjužet in “Wandering Rocks”"
-tags:
-- name: Moacir P. de Sá Pereira
-  url: http://moacir.com
+tags:  
+ - Moacir P. de Sá Pereira
 category: literary-modeling-and-visualization-lab
 type: geocoding
 image: fabulaandsjuzet.png

--- a/_posts/projects/2017-02-04-macro-etymological-analyzer.md
+++ b/_posts/projects/2017-02-04-macro-etymological-analyzer.md
@@ -1,9 +1,8 @@
 ---
 layout: project
 title: "Macro-Etymological Textual Analysis"
-tags:
-- name: Jonathan Reeve
-  url: http://jonreeve.com
+tags: 
+ - Jonathan Reeve
 category: literary-modeling-and-visualization-lab
 published: true
 snippet: 82

--- a/_posts/projects/2017-02-04-middlemarch-critical-histories.md
+++ b/_posts/projects/2017-02-04-middlemarch-critical-histories.md
@@ -1,13 +1,10 @@
 ---
 layout: project
 title: "Middlemarch Critical Histories"
-tags:
-- name: Jonathan Reeve
-  url: http://jonreeve.com
-- name: Milan Terlunen 
-  url: http://xpmethod.github.io
-- name: Sierra Eckert 
-  url: http://xpmethod.github.io
+tags: 
+ - Jonathan Reeve
+ - Milan Terlunen
+ - Sierra Eckert
 category: literary-modeling-and-visualization-lab
 published: true
 snippet: 82

--- a/_posts/projects/2017-1-24-jail-of-mountjoy.md
+++ b/_posts/projects/2017-1-24-jail-of-mountjoy.md
@@ -1,9 +1,7 @@
 ---
 layout: project
 title: "Jail of Mountjoy"
-tags:
-- name: Casey Michael Henry
-  url: http://jailofmountjoy.newmedialab.cuny.edu/
+tags: Casey Michael Henry
 category: literary-modeling-and-visualization-lab
 type: graphic
 snippet: 350

--- a/public/css/screen.sass
+++ b/public/css/screen.sass
@@ -110,6 +110,8 @@ div.update-list
       content: ", "
     &:last-child:after
       content: ""
+    &:nth-last-child(2):after
+      content: ", & "
 
 .event
   .date


### PR DESCRIPTION
This has the effect of generally cleaning up some things: 

 - Personal website URLs are only written once, in the contributors.yaml data file, rather than on each project page.  
 - Solves the problem in #198 of duplicate entries caused by some project tags containing URLs, while others do not.
 - Allows us to have some project contributors with personal website URLs, and others without. Before, every project contributor had to have a URL if one did.  