### PR TITLE
add project status badges using GitHub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#xpmethod.github.io
+# xpmethod.github.io
 [![Build Status](https://travis-ci.org/xpmethod/xpmethod.github.io.svg?branch=master)](https://travis-ci.org/xpmethod/xpmethod.github.io)
 
 This page describes the file structure and the taxonomy of xpmethod.github.io

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -18,6 +18,20 @@ url: research/
         </ul>
     {% endif %}
 
+        <!-- Include GitHub badges if the project has a GitHub repo. -->
+        {% if page.github %}
+        <ul class="github-badges">
+            <li>
+                <a href="https://github.com/{{ page.github }}/issues">
+                <img src="https://img.shields.io/github/issues/{{ page.github }}.svg?style=flat-square"/>
+                </a>
+            </li>
+            <li><img src="https://img.shields.io/github/languages/top/{{ page.github }}.svg?style=flat-square"/></li> 
+            <li><img src="https://img.shields.io/github/commit-activity/y/{{ page.github }}.svg?style=flat-square"/></li>
+        </ul>
+        <a href="https://github.com/{{ page.github }}">Go to the project's GitHub repository.</a>
+        {% endif %} 
+
     <!-- grab image from yaml if there is one -->
         {% if page.image %}
             <div id="feature">

--- a/_posts/projects/2016-12-04-nywalker.md
+++ b/_posts/projects/2016-12-04-nywalker.md
@@ -6,6 +6,7 @@ tags:
 category: embodied-space-lab
 type: geocoding
 image: nywalker.png
+github: nyscapes/nywalker
 ---
 
 Read the [README](https://github.com/nyscapes/nywalker) at GitHub.

--- a/_posts/projects/2017-01-07-mapping-fabula-and-sjuzet.md
+++ b/_posts/projects/2017-01-07-mapping-fabula-and-sjuzet.md
@@ -6,9 +6,9 @@ tags:
 category: literary-modeling-and-visualization-lab
 type: geocoding
 image: fabulaandsjuzet.png
+github: muziejus/wandering-rocks
 ---
 
-Read the [README](https://github.com/muziejus/wandering-rocks) at GitHub.
 [Mapping Fabula and Sjužet in “Wandering
 Rocks”](http://muziejus.github.io/wandering-rocks) as hosted by GitHub.
 

--- a/_posts/projects/2017-02-04-macro-etymological-analyzer.md
+++ b/_posts/projects/2017-02-04-macro-etymological-analyzer.md
@@ -10,6 +10,7 @@ updates:
 - date: 12/16
   text: '“A Macro-Etymological Analysis of James Joyce’s A Portrait of the Artist as a Young Man” published in _Reading Modernism with Machines_, Palgrave Macmillan, 2016'
   type: publication
+github: JonathanReeve/macro-etym
 ---
 
 Word histories are correlated strongly with the tone and genre of a text. When a writer chooses the word “enchantment” instead of “spell,” or “inquire” instead of “ask,” this decision may indicate, to some degree, the speaker’s mode, dialect, or level of formality. These modes may be then be measured by quantifying the aggregated etymology of an entire text. [The Macro-Etymological Analyzer](https://github.com/JonathanReeve/macro-etym) is a command-line utility, written in Python, that quantifies the etymologies of a text using the [Etymological Wordnet](http://www1.icsi.berkeley.edu/~demelo/etymwn/). 

--- a/_posts/projects/2017-02-04-middlemarch-critical-histories.md
+++ b/_posts/projects/2017-02-04-middlemarch-critical-histories.md
@@ -8,9 +8,8 @@ tags:
 category: literary-modeling-and-visualization-lab
 published: true
 snippet: 82
+github: lit-mod-viz/middlemarch-critical-histories
 ---
-
-(The main project page may be found [here, via the XPMethod GitHub Organization](https://github.com/xpmethod/middlemarch-critical-histories).)
 
 Text reuse detection technology and approximate text matching have made possible the large-scale computational identification of intertextuality. These technologies have often been used in plagiarism detection and in studies of journalistic text reuse. Fewer studies, however, have applied these methods to humanities research. We present a method for quantifying the critical reception history of a source text by analyzing the precise location, density and chronology of its citations.
 

--- a/_posts/projects/2017-10-02-jekyll-wax.md
+++ b/_posts/projects/2017-10-02-jekyll-wax.md
@@ -6,6 +6,7 @@ tags:
 category: knowledge-design-studio
 type: tools
 published: true
+github: mnyrop/wax
 ---
 
 __Jekyll-Wax__ is a heterogeneous collection of experiments, strategies, and

--- a/_posts/projects/2017-10-23-nimble-tents.md
+++ b/_posts/projects/2017-10-23-nimble-tents.md
@@ -8,6 +8,7 @@ tags:
 - Alex Gil
 - Manan Ahmed
 updates:
+github: nimbletents/nimbletents.github.io
 ---
 
 Universities and Colleges, and their Libraries and Digital Scholarship Labs in particular, have the latent capacity to gather quickly and react to the urgencies we can expect from the anthropocene and our vulnerable political landscapes: reams of good will, talent, space, colleague networks, communication and management lines, pedagogical wherewithal, computational savvy, and much more. The *nimble tents toolkit* provides timelines, instructions and sample materials to help your team and organization tap into that potential.

--- a/public/css/screen.sass
+++ b/public/css/screen.sass
@@ -133,6 +133,11 @@ div.update-list
   margin: .5em -2em
   padding: 1em 2em
 
+ul.github-badges li
+  list-style-type: none
+  display: inline-block
+  margin-right: 1em
+
 // This Flexbox model apparently doesn't work 
 // on all browsers. Older Firefox doesn't seem to work. 
 // Let's put this on hold temporarily, until we can 


### PR DESCRIPTION
This fixes #225 by adding [shield.io](https://shield.io) badges, dynamically generated from GitHub repos. This should give potential collaborators an idea of how active a project is (number of commits in the past year), how much help it needs (open issue counts), and whether the project is mostly in a language that the potential collaborator knows (primary repo language). 

For this to work, project pages should have the YAML metadata item `github: ` with the value `username/repo`, as in the examples below. I've added a few already, but not all project pages have this yet. 

Here's a screenshot: 

![screenshot from 2018-01-27 11-28-22](https://user-images.githubusercontent.com/1843676/35474000-35c58730-0356-11e8-96f3-6a43da160615.png)
